### PR TITLE
feat(miniplayer): improve button positioning and lifecycle management

### DIFF
--- a/public/miniplayer.css
+++ b/public/miniplayer.css
@@ -1,10 +1,10 @@
 .miniplayer-btn {
   position: fixed;
   z-index: 1000000;
- background: rgba(0, 0, 0, 0.6);
+  background: rgba(0, 0, 0, 0.6);
   border: none;
   border-radius: 4px;
- width: 36px;
+  width: 36px;
   height: 36px;
   cursor: pointer;
   display: flex;


### PR DESCRIPTION
- Add event listeners to update miniplayer button position on video metadata load and resize events
- Implement cleanup of event listeners when removing miniplayer buttons
- Adjust button positioning logic for fixed positioning using viewport coords
- Add resetAllButtons function to recreate buttons on URL changes
- Introduce URL change monitoring for SPA navigation (e.g. YouTube video switch) to properly reset miniplayer buttons
- Delayed re-processing of videos after URL change to handle dynamic loading